### PR TITLE
Fix (admin home events) View correct event info

### DIFF
--- a/src/views/flightPlanViews/admin/AdminHome.vue
+++ b/src/views/flightPlanViews/admin/AdminHome.vue
@@ -326,7 +326,7 @@ const getSelectedTask = (name, task, reflection, id) => {
 }
 
 const getSelectedEvent = (index) => {
-  selectedEvent.value = upcomingEvents.value[index];
+  selectedEvent.value = upcomingEvents.value[(currentEventPage.value - 1) * itemsPerPage + index];
   viewingEvent.value = !viewingEvent.value;
 }
 


### PR DESCRIPTION
Updated index to correctly get the id for the event on events past the first list page